### PR TITLE
Add optional format argument for ipv6_subnetid

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Calculate IPv6 address segments entirely in bash
 
 Based loosely on wg-ip (https://github.com/chmduquesne/wg-ip)
+IPv6 definitions from https://en.wikipedia.org/wiki/IPv6_address
 
 Frank Crawford - <frank@crawford.emu.id.au> - 31-Jul-2021
 
@@ -17,8 +18,8 @@ compress_ipv6 $ip
 ipv6_prefix $ip $subnet
 - extract the IPv6 routing prefix from $ip with subnet length $subnet
 
-ipv6_subnetid $ip $subnet
-- extract the local subnet ID from unicast address ($ip)
+ipv6_subnetid $ip $subnet $fmt
+- extract the local subnet ID from unicast address ($ip) with optional $fmt
 
 ipv6_interface $ip
 - IPv6 host or interface part of address ($ip)

--- a/ipv6_test.sh
+++ b/ipv6_test.sh
@@ -16,8 +16,8 @@ do
 	echo "Prefix/${sn}: $(ipv6_prefix $ip $sn)"
 	echo "Prefix/56: $(ipv6_prefix $ip 56)"
 	echo "Interface ID: $(ipv6_interface $ip)"
-	echo "Subnet ID/${sn}: $(ipv6_subnetid $ip $sn)"
-	echo "Subnet ID/56: $(ipv6_subnetid $ip 56)"
+	echo "Subnet ID/${sn} (hex/dec): $(ipv6_subnetid $ip $sn)/$(ipv6_subnetid $ip $sn '%d')"
+	echo "Subnet ID/56 (hex/dec): $(ipv6_subnetid $ip 56)/$(ipv6_subnetid $ip 56 '%d')"
 
 	echo "Address type: $(ipv6_type $ip)"
 

--- a/ipv6_utils.sh
+++ b/ipv6_utils.sh
@@ -13,8 +13,8 @@
 # - returns compressed IPv6 address ($ip) under the form recommended by RFC5952
 # ipv6_prefix $ip $subnet
 # - extract the IPv6 routing prefix from $ip with subnet length $subnet
-# ipv6_subnetid $ip $subnet
-# - extract the local subnet ID from unicast address ($ip)
+# ipv6_subnetid $ip $subnet $fmt
+# - extract the local subnet ID from unicast address ($ip) with optional $fmt
 # ipv6_interface $ip
 # - IPv6 host or interface part of address ($ip)
 # ipv6_split_mask $ip/$mask
@@ -140,6 +140,7 @@ ipv6_prefix() {
 ipv6_subnetid() {
     local ip=$(expand_ipv6 $1)
     local subnet=${2:-64}
+    local fmt="${3:-%x}"
 
     local len=$(( 64-$subnet ))
 
@@ -148,7 +149,7 @@ ipv6_subnetid() {
 	echo -n '-'
     else
         ip=${ip//:/}
-        printf "%x" "$(( 0x${ip:14:2} & ((1<<$len)-1) ))"
+        printf "$fmt" "$(( 0x${ip:14:2} & ((1<<$len)-1) ))"
     fi
 }
 


### PR DESCRIPTION
Defaults to %x, but useful to set %d or even 0x%x for clarity.